### PR TITLE
non-standard HTTP requests are bad foo. Android won't accept that via…

### DIFF
--- a/src/cli/node/realServer.js
+++ b/src/cli/node/realServer.js
@@ -15,7 +15,13 @@ export function makeAuthRequest (apiKey) {
     xhr.open(method, uri)
     xhr.setRequestHeader('Content-Type', 'application/json')
     xhr.setRequestHeader('Authorization', 'Token ' + apiKey)
-    xhr.send(JSON.stringify(body))
+    // DELETE, POST, and PUT can all have request bodies
+    // But GET cannot, otherwise it becomes non-standard
+    if(method !== 'GET') {
+      xhr.send(JSON.stringify(body));
+    } else {
+      xhr.send();
+    }
     console.log(method + ' ' + uri)
   }
 }

--- a/src/context.js
+++ b/src/context.js
@@ -49,7 +49,13 @@ export function Context (opts) {
     xhr.setRequestHeader('Authorization', 'Token ' + opts.apiKey)
     xhr.setRequestHeader('Content-Type', 'application/json')
     xhr.setRequestHeader('Accept', 'application/json')
-    xhr.send(JSON.stringify(body))
+    // DELETE, POST, and PUT can all have request bodies
+    // But GET cannot, otherwise it becomes non-standard
+    if(method !== 'GET') {
+      xhr.send(JSON.stringify(body));
+    } else {
+      xhr.send();
+    }
     console.log('Visit ' + uri)
   }
   this.authFetch = opts.authRequest || webFetch


### PR DESCRIPTION
… React Native so we remove the body from the request if it's a GET request