### PR TITLE
Do not process source files through babel es2015 for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   ],
   "main": "lib/indexABC.js",
   "module": "lib/indexABC.es.js",
+  "react-native": "lib/indexABC.rn.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:Airbitz/airbitz-core-js.git"
   },
   "scripts": {
-    "build": "webpack && rollup -c && npm run build:types",
+    "build": "webpack && rollup -c && rollup -c rollup.config.rn.js && npm run build:types",
+    "webpack": "webpack",
     "build:test": "webpack && rollup -c rollup.config.test.js",
     "build:types": "flow-copy-source -i '**/*.test.js' src lib",
     "flow": "flow status",

--- a/rollup.config.rn.js
+++ b/rollup.config.rn.js
@@ -1,0 +1,31 @@
+import babel from 'rollup-plugin-babel'
+import commonjs from 'rollup-plugin-commonjs'
+import packageJson from './package.json'
+
+const babelOpts = {
+  presets: ['flow'],
+  plugins: [
+    'transform-object-rest-spread'
+  ]
+}
+
+export default {
+  entry: 'src/indexABC.js',
+  external: [
+    ...Object.keys(packageJson.dependencies),
+    ...Object.keys(packageJson.devDependencies)
+  ],
+  plugins: [
+    commonjs({
+      include: 'build/crypto-bundle.js'
+    }),
+    babel(babelOpts)
+  ],
+  targets: [
+    {
+      dest: packageJson['react-native'],
+      format: 'es',
+      sourceMap: true
+    }
+  ]
+}


### PR DESCRIPTION
On Android we hit a problem whereby es2015 babel plugin will create nested functions inside IF statements which causes an error in RN since "use strict" is on by default. This change creates a separate build for react native that is only processed for flow and spread operators. This fixes Android and tested to still work on iOS. Performance on ios appears unchanged from prior to this PR