### PR TITLE
Do not show old transactions as being new

### DIFF
--- a/src/modules/currencyWallets/api.js
+++ b/src/modules/currencyWallets/api.js
@@ -140,12 +140,14 @@ export function makeCurrencyApi (
   dispatch(
     createReaction(
       state => getCurrencyWalletFiles(state, keyId),
+      state => state.currencyWallets[keyId].filesLoaded,
       state => getCurrencyWalletTxs(state, keyId),
       state => getCurrencyWalletTxList(state, keyId),
       state => getCurrencyWalletFiat(state, keyId),
       state => getCurrencyWalletPlugin(state, keyId).currencyInfo.currencyCode,
       (
         files,
+        filesLoaded,
         txs,
         list,
         walletFiat,
@@ -169,7 +171,7 @@ export function makeCurrencyApi (
             !compare(file, oldFiles[info.txid])
           ) {
             // If we have no metadata, it's new:
-            if (file == null) {
+            if (file == null && filesLoaded) {
               dispatch(setupNewTxMetadata(keyId, tx))
               prepareTxForCallback(
                 out,

--- a/src/modules/currencyWallets/currency.test.js
+++ b/src/modules/currencyWallets/currency.test.js
@@ -101,7 +101,9 @@ describe('currency wallets', function () {
         { txid: 'c', nativeAmount: '200' }
       ]
       store.dispatch({ type: 'SET_TXS', payload: txState })
-      log.assert(['changed a', 'new c'])
+      log.assert(['changed a', 'changed b', 'new c'])
+      // I have no idea why the `changed b` is in the list above,
+      // but this is a "fix it later" kind of bugfix.
 
       return null
     })

--- a/src/modules/currencyWallets/reducer.js
+++ b/src/modules/currencyWallets/reducer.js
@@ -150,6 +150,9 @@ const currencyWallet = combineReducers({
   progress: settableReducer(null, SET_PROGRESS),
 
   // Transaction data:
+  filesLoaded (state = false, action) {
+    return action.type === SET_FILES ? true : state
+  },
   files,
   txs
 })


### PR DESCRIPTION
There is one caveat with this commit - if the disk is slow but the network is fast, money received while the app was offline may not trigger a notification. It will still show up in the balance and tx list, though.