### PR TITLE
Improve the login performance

### DIFF
--- a/src/modules/account/accountState.js
+++ b/src/modules/account/accountState.js
@@ -109,11 +109,14 @@ class AccountState {
     })
     this.activeLoginId = ai.props.state.login.lastActiveLoginId
 
-    const { activeLoginId } = this
-    dispatch({
-      type: 'ACCOUNT_KEYS_LOADED',
-      payload: { activeLoginId, walletInfos: this.allKeys }
-    })
+    // While it would make logical sense to do this now,
+    // starting the wallet engines is too expensive,
+    // so we allow the data sync to trigger the work later:
+    // const { activeLoginId } = this
+    // dispatch({
+    //   type: 'ACCOUNT_KEYS_LOADED',
+    //   payload: { activeLoginId, walletInfos: this.allKeys }
+    // })
   }
 
   async logout () {


### PR DESCRIPTION
The keys were being added to Redux too early in the login process, causing the app to start the wallet engines before the account had a chance to resolve. This did a huge amount of sync crypto work, bogging down the login.