### PR TITLE
Switch to the v2 OTP reset endpoint

### DIFF
--- a/src/modules/context/context-api-pixie.js
+++ b/src/modules/context/context-api-pixie.js
@@ -187,7 +187,7 @@ function makeContextApi (ai: ApiInput) {
       })
     },
 
-    requestOtpReset (username: string, otpResetToken: string): Promise<void> {
+    requestOtpReset (username: string, otpResetToken: string): Promise<Date> {
       return resetOtp(ai, username, otpResetToken)
     },
 

--- a/src/modules/login/login.js
+++ b/src/modules/login/login.js
@@ -342,12 +342,15 @@ export async function resetOtp (
   ai: ApiInput,
   username: string,
   resetToken: string
-): Promise<void> {
+): Promise<Date> {
   const request = {
-    l1: base64.stringify(await hashUsername(ai, username)),
-    otp_reset_auth: resetToken
+    userId: base64.stringify(await hashUsername(ai, username)),
+    otpResetAuth: resetToken
   }
-  return authRequest(ai, 'POST', '/v1/otp/reset', request)
+  return authRequest(ai, 'DELETE', '/v2/login/otp', request).then(reply => {
+    // The server returns dates as ISO 8601 formatted strings:
+    return new Date(reply.otpResetDate)
+  })
 }
 
 /**


### PR DESCRIPTION
This allows us to return the reset date as part of the response.

Requires https://github.com/Airbitz/airbitz-core-types/pull/8 and https://github.com/Airbitz/airbitz-wallet-server/pull/7