### PR TITLE
Wallet sync

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -127,6 +127,20 @@ export interface LogoutAction {
   payload: { activeLoginId: string };
 }
 
+/**
+ * Fires when a repo has been synced.
+ */
+export interface RepoSynced {
+  type: 'REPO_SYNCED';
+  payload: {
+    changes: Array<string>,
+    status: {
+      lastHash: string,
+      lastSync: number
+    }
+  };
+}
+
 export type RootAction =
   | AccountKeysLoadedAction
   | CurrencyEngineChangedTxs
@@ -139,3 +153,4 @@ export type RootAction =
   | InitAction
   | LoginAction
   | LogoutAction
+  | RepoSynced

--- a/src/modules/currency/wallet/currency-wallet-callbacks.js
+++ b/src/modules/currency/wallet/currency-wallet-callbacks.js
@@ -7,7 +7,7 @@ import type {
 import { isPixieShutdownError } from 'redux-pixies'
 
 import { compare } from '../../../util/compare.js'
-import { getStorageWalletLastSync } from '../../storage/selectors.js'
+import { getStorageWalletLastChanges } from '../../storage/selectors.js'
 import { combineTxWithFile } from './currency-wallet-api.js'
 import { loadAllFiles, setupNewTxMetadata } from './currency-wallet-files.js'
 import type {
@@ -161,8 +161,8 @@ export function watchCurrencyWallet (input: CurrencyWalletInput) {
     }
 
     if (
-      getStorageWalletLastSync(props.state, walletId) !==
-      getStorageWalletLastSync(lastProps.state, walletId)
+      getStorageWalletLastChanges(props.state, walletId) !==
+      getStorageWalletLastChanges(lastProps.state, walletId)
     ) {
       // Reload our data from disk:
       loadAllFiles(input).catch(e => input.props.onError(e))

--- a/src/modules/currency/wallet/currency-wallet-callbacks.js
+++ b/src/modules/currency/wallet/currency-wallet-callbacks.js
@@ -145,12 +145,13 @@ export function makeCurrencyWalletCallbacks (
 export function watchCurrencyWallet (input: CurrencyWalletInput) {
   const walletId = input.props.id
 
-  let lastProps = input.props
+  let lastChanges
+  let lastName
   function checkChangesLoop (props: CurrencyWalletProps) {
-    lastProps = props
-
-    if (props.selfState.name !== lastProps.selfState.name) {
-      const name = props.selfState.name
+    // Check for name changes:
+    const name = props.selfState.name
+    if (name !== lastName) {
+      lastName = name
 
       // Call onWalletNameChanged:
       forEachListener(input, ({ onWalletNameChanged }) => {
@@ -160,10 +161,11 @@ export function watchCurrencyWallet (input: CurrencyWalletInput) {
       })
     }
 
-    if (
-      getStorageWalletLastChanges(props.state, walletId) !==
-      getStorageWalletLastChanges(lastProps.state, walletId)
-    ) {
+    // Check for data changes:
+    const changes = getStorageWalletLastChanges(props.state, walletId)
+    if (changes !== lastChanges) {
+      lastChanges = changes
+
       // Reload our data from disk:
       loadAllFiles(input).catch(e => input.props.onError(e))
 

--- a/src/modules/root-reducer.js
+++ b/src/modules/root-reducer.js
@@ -10,11 +10,13 @@ import type { LoginState } from './login/login-reducer.js'
 import login from './login/login-reducer.js'
 import scrypt from './scrypt/reducer.js'
 import storageWallets from './storage/reducer.js'
+import type { StorageWalletState } from './storage/reducer.js'
 
 export interface RootState {
   currency: CurrencyState;
   io: AbcIo;
   login: LoginState;
+  storageWallets: { [walletId: string]: StorageWalletState };
 }
 
 function io (state = {}, action: RootAction) {

--- a/src/modules/storage/actions.js
+++ b/src/modules/storage/actions.js
@@ -1,7 +1,7 @@
 import { base58, base64 } from '../../util/encoding.js'
 import { getIo } from '../selectors.js'
 import { loadRepoStatus, makeRepoPaths, syncRepo } from '../storage/repo.js'
-import { add, setStatus } from './reducer.js'
+import { add, update } from './reducer.js'
 
 export function addStorageWallet (keyInfo, onError) {
   return (dispatch, getState) => {
@@ -32,7 +32,11 @@ export function syncStorageWallet (keyId) {
     const { paths, status } = state.storageWallets[keyId]
 
     return syncRepo(io, paths, { ...status }).then(({ changes, status }) => {
-      dispatch(setStatus(keyId, status))
+      const action = {
+        type: 'REPO_SYNCED',
+        payload: { changes: Object.keys(changes), status }
+      }
+      dispatch(update(keyId, action))
       return Object.keys(changes)
     })
   }

--- a/src/modules/storage/reducer.js
+++ b/src/modules/storage/reducer.js
@@ -1,34 +1,54 @@
+// @flow
 import { combineReducers } from 'redux'
 
-import {
-  constReducer,
-  listReducer,
-  settableReducer
-} from '../../util/redux/reducers.js'
+import { listReducer } from '../../util/redux/reducers.js'
+import type { RootAction } from '../actions.js'
+
+export interface StorageWalletState {
+  lastChanges: Array<string>;
+  status: {
+    lastHash: string | void,
+    lastSync: number
+  };
+}
 
 const ADD = 'airbitz-core-js/storageWallet/ADD'
 const UPDATE = 'airbitz-core-js/storageWallet/UPDATE'
-const SET_STATUS = 'airbitz-core-js/storageWallet/SET_STATUS'
 
-export function add (keyId, initialState) {
+export function add (keyId: string, initialState: any) {
   return { type: ADD, payload: { id: keyId, initialState } }
 }
 
-export function update (keyId, action) {
+export function update (keyId: string, action: RootAction) {
   return { type: UPDATE, payload: { id: keyId, action } }
 }
 
-export function setStatus (keyId, status) {
-  return update(keyId, { type: SET_STATUS, payload: status })
-}
-
 /**
- * Individual wallet reducer.
+ * Individual repo reducer.
  */
 const storageWallet = combineReducers({
-  localFolder: constReducer(),
-  paths: constReducer(),
-  status: settableReducer({}, SET_STATUS)
+  lastChanges (state = [], action: RootAction): Array<string> {
+    if (action.type === 'REPO_SYNCED') {
+      const { changes } = action.payload
+      return changes.length ? changes : state
+    }
+    return state
+  },
+
+  localFolder (state = null) {
+    return state
+  },
+
+  paths (state = null) {
+    return state
+  },
+
+  status (state = { lastSync: 0 }, action: RootAction) {
+    if (action.type === 'REPO_SYNCED') {
+      return action.payload.status
+    }
+    return state
+  }
 })
 
 /**

--- a/src/modules/storage/selectors.js
+++ b/src/modules/storage/selectors.js
@@ -2,8 +2,8 @@ import { hmacSha256 } from '../../util/crypto/crypto.js'
 import { base58, utf8 } from '../../util/encoding.js'
 import { RepoFolder } from './repoFolder.js'
 
-export function getStorageWalletLastSync (state, keyId) {
-  return state.storageWallets[keyId].status.lastSync
+export function getStorageWalletLastChanges (state, keyId) {
+  return state.storageWallets[keyId].lastChanges
 }
 
 export function getStorageWalletFolder (state, keyId) {

--- a/src/modules/storage/storageApi.js
+++ b/src/modules/storage/storageApi.js
@@ -6,7 +6,7 @@ import type { ApiInput } from '../root.js'
 import { addStorageWallet, syncStorageWallet } from './actions.js'
 import {
   getStorageWalletFolder,
-  getStorageWalletLastSync,
+  getStorageWalletLastChanges,
   getStorageWalletLocalFolder
 } from './selectors.js'
 
@@ -33,8 +33,8 @@ export function makeStorageWalletApi (
   if (onDataChanged) {
     dispatch(
       createReaction(
-        state => getStorageWalletLastSync(state, id),
-        onDataChanged
+        state => getStorageWalletLastChanges(state, id),
+        changes => onDataChanged(changes)
       )
     )
   }

--- a/src/util/redux/reducers.js
+++ b/src/util/redux/reducers.js
@@ -1,14 +1,4 @@
 /**
- * A no-op reducer.
- * The state would generally be pre-loaded at store creation time.
- */
-export function constReducer (initialState = null) {
-  return function constReducer (state = initialState, action) {
-    return state
-  }
-}
-
-/**
  * Creates a reducer for managing a key/value collection.
  * @param {*} itemReducer The reducer to use on the individual items.
  * @param {*} ACTIONS An object with the strings to use for the
@@ -38,14 +28,5 @@ export function listReducer (itemReducer, ACTIONS = {}) {
       }
     }
     return state
-  }
-}
-
-/**
- * A simple settable value reducer.
- */
-export function settableReducer (initialState, SET) {
-  return function settableReducer (state = initialState, action) {
-    return action.type === SET ? action.payload : state
   }
 }


### PR DESCRIPTION
This gives us the basic periodic backup functionality. I do not call `onTransactionsChanged` in response to sync, though, so you won't see metadata update "live" between two phones.