### PR TITLE
Set networkFeeOption on an exchange makeSpend.

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -193,6 +193,7 @@ export function makeCurrencyWalletApi (
           }
 
           const exchangeSpendInfo: EdgeSpendInfo = {
+            networkFeeOption: spendInfo.networkFeeOption,
             currencyCode: spendInfo.currencyCode,
             spendTargets: [spendTarget]
           }


### PR DESCRIPTION
Shapeshift makeSpends were always using standard fee. This utilizes the networkFeeOption passed in the AbcSpendInfo object