### PR TITLE
Legacy address makespend

### DIFF
--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -620,7 +620,8 @@ export type EdgeEncodeUri = {
 
 export type EdgeFreshAddress = {
   publicAddress: string,
-  segwitAddress?: string
+  segwitAddress?: string,
+  legacyAddress?: string
 }
 
 export type EdgeDataDump = {

--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -537,6 +537,7 @@ export type EdgeSpendTarget = {
 export type EdgeSpendInfo = {
   currencyCode?: string,
   noUnconfirmed?: boolean,
+  allowLegacyAddress?: boolean,
   spendTargets: Array<EdgeSpendTarget>,
   nativeAmount?: string,
   networkFeeOption?: string,

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -229,6 +229,7 @@ export function makeCurrencyWalletApi (
           const exchangeSpendInfo: EdgeSpendInfo = {
             networkFeeOption: spendInfo.networkFeeOption,
             currencyCode: spendInfo.currencyCode,
+            allowLegacyAddress: true,
             spendTargets: [spendTarget]
           }
 

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -153,6 +153,7 @@ export function makeCurrencyWalletApi (
         metadata: fakeMetadata,
         nativeAmount: '0',
         publicAddress: freshAddress.publicAddress,
+        legacyAddress: freshAddress.legacyAddress,
         segwitAddress: freshAddress.segwitAddress
       }
       return Promise.resolve(receiveAddress)
@@ -186,10 +187,22 @@ export function makeCurrencyWalletApi (
           ? spendInfo.spendTargets[0].currencyCode
           : destWallet.currencyInfo.currencyCode
         if (destCurrencyCode !== currentCurrencyCode) {
-          const currentPublicAddress = engine.getFreshAddress().publicAddress
-          const addressInfo = await destWallet.getReceiveAddress()
-          const destPublicAddress = addressInfo.publicAddress
+          const edgeFreshAddress = engine.getFreshAddress()
+          const edgeReceiveAddress = await destWallet.getReceiveAddress()
 
+          let destPublicAddress
+          if (edgeReceiveAddress.legacyAddress) {
+            destPublicAddress = edgeReceiveAddress.legacyAddress
+          } else {
+            destPublicAddress = edgeReceiveAddress.publicAddress
+          }
+
+          let currentPublicAddress
+          if (edgeFreshAddress.legacyAddress) {
+            currentPublicAddress = edgeFreshAddress.legacyAddress
+          } else {
+            currentPublicAddress = edgeFreshAddress.publicAddress
+          }
           const exchangeData = await shapeshiftApi.getSwapAddress(
             currentCurrencyCode,
             destCurrencyCode,


### PR DESCRIPTION
Use legacyAddress if available when giving an address to ShapeShift. Tested to work with a ShapeShift transaction into a BCH wallet.

Also set the allowLegacyAddress boolean when doing a makeSpend to ShapeShift. This is not implemented yet in the currency plugins but will be for LTC and BCH which have legacy address formats which are normally not allowed to spend to without this flag.