### PR TITLE
Use legacyAddress if available for Shapeshift makeSpend

### DIFF
--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -551,7 +551,8 @@ export type EdgeEncodeUri = {
 
 export type EdgeFreshAddress = {
   publicAddress: string,
-  segwitAddress?: string
+  segwitAddress?: string,
+  legacyAddress?: string
 }
 
 export type EdgeDataDump = {

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -132,6 +132,7 @@ export function makeCurrencyWalletApi (
         metadata: fakeMetadata,
         nativeAmount: '0',
         publicAddress: freshAddress.publicAddress,
+        legacyAddress: freshAddress.legacyAddress,
         segwitAddress: freshAddress.segwitAddress
       }
       return Promise.resolve(receiveAddress)
@@ -165,10 +166,22 @@ export function makeCurrencyWalletApi (
           ? spendInfo.spendTargets[0].currencyCode
           : destWallet.currencyInfo.currencyCode
         if (destCurrencyCode !== currentCurrencyCode) {
-          const currentPublicAddress = engine.getFreshAddress().publicAddress
-          const addressInfo = await destWallet.getReceiveAddress()
-          const destPublicAddress = addressInfo.publicAddress
+          const edgeFreshAddress = engine.getFreshAddress()
+          const edgeReceiveAddress = await destWallet.getReceiveAddress()
 
+          let destPublicAddress
+          if (edgeReceiveAddress.legacyAddress) {
+            destPublicAddress = edgeReceiveAddress.legacyAddress
+          } else {
+            destPublicAddress = edgeReceiveAddress.publicAddress
+          }
+
+          let currentPublicAddress
+          if (edgeFreshAddress.legacyAddress) {
+            currentPublicAddress = edgeFreshAddress.legacyAddress
+          } else {
+            currentPublicAddress = edgeFreshAddress.publicAddress
+          }
           const exchangeData = await shapeshiftApi.getSwapAddress(
             currentCurrencyCode,
             destCurrencyCode,


### PR DESCRIPTION
Allows ShapeShift to receive legacy addresses so they won't break.
Requires edge-currency-bitcoin version > 2.14.1 to work.